### PR TITLE
ETU-60697: Better support for TestInstance.Lifecycle.PER_CLASS in JUnit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Release notes](https://github.com/entur/oidc-auth-client)
 
+## oidc-auth-resource-server v1.0.2
+* Make method TenantJsonWebToken.setupTokenFactory public
+
 ## oidc-auth-resource-server v1.0.1
 * Fix TenantAnnotationTokenFactory don't handle PortReservation correct
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ class AuthorizeTest {
 }
 ```
 
+> [!TIP]
+> When configure test clas with: ```@TestInstance(TestInstance.Lifecycle.PER_CLASS)``` may it be necessary to use ```@DynamicPropertySource``` and call ```TenantJsonWebToken.setupTokenFactory()```.
+
 ## Customising the SecurityFilterChain
 If additional customising of SecurityFilterChain is needed, it can be provided by implementing own Spring Bean's.
 

--- a/oidc-rs-junit-tenant/src/main/java/org/entur/auth/junit/tenant/TenantJsonWebToken.java
+++ b/oidc-rs-junit-tenant/src/main/java/org/entur/auth/junit/tenant/TenantJsonWebToken.java
@@ -130,12 +130,16 @@ public class TenantJsonWebToken implements ParameterResolver, BeforeAllCallback 
         throw new CanNotResolveParameterException();
     }
 
-    private static void setupTokenFactory() {
+    public static void setupTokenFactory() {
         // this code should run before the spring context starts, but in case the class is not loaded,
         // the spring context will run first.
         // In which case the MOCKAUTHSERVER_PORT port must be a free port.
         if (portReservation == null) {
             portReservation = new PortReservation(MOCKAUTHSERVER_PORT_NAME);
+        }
+
+        // Initiate portReservation
+        if (portReservation.getPort() < 0) {
             portReservation.start();
         }
 

--- a/oidc-rs-spring-boot-web-test/src/test/java/org/entur/auth/spring/test/other/LifecycleClassTest.java
+++ b/oidc-rs-spring-boot-web-test/src/test/java/org/entur/auth/spring/test/other/LifecycleClassTest.java
@@ -1,0 +1,41 @@
+package org.entur.auth.spring.test.other;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.entur.auth.junit.tenant.InternalTenant;
+import org.entur.auth.junit.tenant.TenantJsonWebToken;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith({SpringExtension.class, TenantJsonWebToken.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LifecycleClassTest {
+    @Autowired private MockMvc mockMvc;
+
+    @DynamicPropertySource
+    static void registerProps(DynamicPropertyRegistry registry) {
+        TenantJsonWebToken.setupTokenFactory();
+    }
+
+    @Test
+    void testInternal(@InternalTenant(clientId = "clientId") String authorization) throws Exception {
+        var requestHeaders = new HttpHeaders();
+        requestHeaders.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        requestHeaders.add("Authorization", authorization);
+
+        mockMvc.perform(get("/internal").headers(requestHeaders)).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
When JUnit is annotated to use Lifecycle.PER_CLASS will Spring Security Context be initiated before TenantJsonWebToken has reserved a port for jwks, and MOCKAUTHSERVER_PORT is not initiated.

Solution:
Make method TenantJsonWebToken.setupTokenFactory public so tests can use:

@DynamicPropertySource
static void registerProps(DynamicPropertyRegistry registry) {
    TenantJsonWebToken.setupTokenFactory();
}