### PR TITLE
SIK-1593: Updated default maven release version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ on:
           - major
           - minor
           - patch
-        default: "minor"
+        default: "patch"
 
 jobs:
   publish:


### PR DESCRIPTION
Closes [SIK-1593].

[SIK-1593]: https://enturas.atlassian.net/browse/SIK-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ