### PR TITLE
ETU-71360: Minor documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ entur:
 entur:
   auth:
     lazy-load: true | false  # When using RSA certificates can JWKS load be delayed. Default = false.
-    retry-on-failure: true | false # When true will failure on loading JWKS be retried. Default = false.
+    retry-on-failure: true | false # When true will failure on loading JWKS be retried. Default = true.
     connect-timeout: <seconds> # Numbus Resource Retriever - connectTimeout. Default = 5 seconds.
     read-timeout: <seconds> # Numbus Resource Retriever - readTimeout. Default = 5 seconds.
     jwks-throttle-wait: <seconds> # Numbus JWKSourceBuilder - rateLimited. Default = 30 seconds.


### PR DESCRIPTION
## 💡 What does this PR do?
This pull request addresses an inconsistency between documentation and implementation regarding the default value of `retry-on-failure` property.

Part of: ETU-71360

## 🔧 List of changes
- Update `README.md`

## 📋 Checklist
- [x] Am familiar with the release pipeline for this project
- [x] I have updated relevant developer documentation
- [x] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes