### PR TITLE
ETU-71360: Address minor typing inconsistency

### DIFF
--- a/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/EnturAuthProperties.java
+++ b/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/EnturAuthProperties.java
@@ -17,7 +17,7 @@ public class EnturAuthProperties {
     private int refreshAheadTime = 30;
     private int cacheRefreshTimeout = 15;
     private int cacheLifespan = 300;
-    private int outageTolerant = 300;
+    private long outageTolerant = 300;
 
     private List<IssuerProperties> issuers = new ArrayList<>();
     private TenantsProperties tenants = new TenantsProperties();

--- a/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/IssuerProperties.java
+++ b/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/IssuerProperties.java
@@ -17,5 +17,5 @@ public class IssuerProperties {
     private Integer refreshAheadTime;
     private Integer cacheRefreshTimeout;
     private Integer cacheLifespan;
-    private Integer outageTolerant;
+    private Long outageTolerant;
 }


### PR DESCRIPTION
## 💡 What does this PR do?
This pull request addresses a minor typing inconsistency for `outageTolerant` value, implementing it as `Long` rather than `Integer` to avoid casting.

Part of: ETU-71360

## 🔧 List of changes
- Use `Long` instead of `Integer` for `outageTolerant` property

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [x] Am familiar with the release pipeline for this project
- [ ] I have updated relevant developer documentation
- [ ] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes