### PR TITLE
ETU-71360: Increase default outage tolerance duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Release notes](https://github.com/entur/oidc-auth-client)
 
+## oidc-auth-resource-server v2.1.0
+* Increase default outage tolerance duration.
+
 ## oidc-auth-resource-server v2.0.0
 * Changed actuator permit from actuator/** too individual paths.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ entur:
     refresh-ahead-time: <seconds> # Numbus RefreshAheadCache - refreshAheadTime. Default = 30 seconds.
     cache-refresh-timeout: <seconds> # Numbus Cache - cacheRefreshTimeout. Default = 15 seconds.
     cache-lifespan: <seconds> # Numbus Cache - cacheLifespan. Default = 300 seconds.
-    outage-tolerant: <seconds> # Numbus Cache - cacheLifespan. Default = 300 seconds.
+    outage-tolerant: <seconds> # Numbus Cache - cacheLifespan. Default = 36000 seconds (10 hours).
 ```
 
 On issuer confguration can this values be overwritten:
@@ -206,7 +206,7 @@ entur:
         refresh-ahead-time: <seconds> # Numbus RefreshAheadCache - refreshAheadTime. 
         cache-refresh-timeout: <seconds> # Numbus Cache - cacheRefreshTimeout. 
         cache-lifespan: <seconds> # Numbus Cache - cacheLifespan. 
-        outage-tolerant: <seconds> # Numbus Cache - outageTolerant. Default = 300 seconds.
+        outage-tolerant: <seconds> # Numbus Cache - outageTolerant. Default = 36000 seconds (10 hours).
 ```
 
 ## Testing

--- a/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/EnturAuthProperties.java
+++ b/oidc-rs-spring-boot-common/src/main/java/org/entur/auth/spring/common/server/EnturAuthProperties.java
@@ -17,7 +17,7 @@ public class EnturAuthProperties {
     private int refreshAheadTime = 30;
     private int cacheRefreshTimeout = 15;
     private int cacheLifespan = 300;
-    private int outageTolerant = 300;
+    private int outageTolerant = 36000;
 
     private List<IssuerProperties> issuers = new ArrayList<>();
     private TenantsProperties tenants = new TenantsProperties();


### PR DESCRIPTION
## 💡 What does this PR do?
This pull request increases the default outage tolerance duration to 10 hours (36000 seconds).

Part of: ETU-71360

## 🔧 List of changes
- Set default value for `outage-tolerant` property to 10 hours (36000 seconds)

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [x] Am familiar with the release pipeline for this project
- [x] I have updated relevant developer documentation
- [x] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes