### PR TITLE
Bean conflict upon construction of JWKS health indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Release notes](https://github.com/entur/oidc-auth-client)
 
+## oidc-auth-resource-server v2.2.2
+* Address a bean conflict issue upon construction of JWKS health indicator
+
 ## oidc-auth-resource-server v2.2.0
 * Change the behaviour of JWKS health indicator.
 

--- a/oidc-rs-spring-boot-web-config/src/main/java/org/entur/auth/spring/config/ConfigJwksHealthIndicatorAutoConfiguration.java
+++ b/oidc-rs-spring-boot-web-config/src/main/java/org/entur/auth/spring/config/ConfigJwksHealthIndicatorAutoConfiguration.java
@@ -30,14 +30,17 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 @ConditionalOnWebApplication(type = SERVLET)
 @ConditionalOnEnabledHealthIndicator("jwks")
 public class ConfigJwksHealthIndicatorAutoConfiguration {
+    private static final String JWKS_CLOCK_QUALIFIER = "jwksClock";
+    private static final String JWKS_HEALTH_EXECUTOR_QUALIFIER = "jwksHealthExecutor";
+
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = JWKS_CLOCK_QUALIFIER)
     public @NonNull Clock jwksClock() {
         return systemDefaultZone();
     }
 
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = JWKS_HEALTH_EXECUTOR_QUALIFIER)
     public @NonNull ExecutorService jwksHealthExecutor() {
         return newSingleThreadExecutor(new CustomizableThreadFactory("jwks-health-"));
     }
@@ -45,8 +48,8 @@ public class ConfigJwksHealthIndicatorAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public @NonNull JwksHealthCache jwksHealthCache(
-            final @NonNull @Qualifier("jwksClock") Clock clock,
-            final @NonNull @Qualifier("jwksHealthExecutor") ExecutorService executor) {
+            final @NonNull @Qualifier(JWKS_CLOCK_QUALIFIER) Clock clock,
+            final @NonNull @Qualifier(JWKS_HEALTH_EXECUTOR_QUALIFIER) ExecutorService executor) {
         return new JwksHealthCache(clock, executor, ofSeconds(5));
     }
 

--- a/oidc-rs-spring-boot-web-config/src/test/java/org/entur/auth/spring/config/ConfigJwksHealthIndicatorAutoConfigurationTest.java
+++ b/oidc-rs-spring-boot-web-config/src/test/java/org/entur/auth/spring/config/ConfigJwksHealthIndicatorAutoConfigurationTest.java
@@ -19,6 +19,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import lombok.val;
@@ -42,7 +44,7 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 @DisplayName("ConfigJwksHealthIndicatorAutoConfiguration test suite")
 class ConfigJwksHealthIndicatorAutoConfigurationTest {
     private static final @NonNull String JWKS_CLOCK_QUALIFIER = "jwksClock";
-    private static final @NonNull String JWKS_HEALTH_EXECUTOR_QUALIFIER = "jwksHealthExecutor";
+    private static final String JWKS_HEALTH_EXECUTOR_QUALIFIER = "jwksHealthExecutor";
     private static final @NonNull String JWKS_HEALTH_CACHE_QUALIFIER = "jwksHealthCache";
     private static final @NonNull String JWKS_HEALTH_INDICATOR_QUALIFIER = "jwksState";
 
@@ -95,6 +97,32 @@ class ConfigJwksHealthIndicatorAutoConfigurationTest {
                                 assertThat(context)
                                         .doesNotHaveBean(JwksHealthCache.class)
                                         .doesNotHaveBean(JwksHealthIndicator.class));
+    }
+
+    @Test
+    void should_still_create_jwks_clock_when_differently_named_clock_bean_exists() {
+        contextRunner
+                .withPropertyValues("management.health.jwks.enabled=true")
+                .withBean("testClock", Clock.class, Clock::systemDefaultZone)
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasBean(JWKS_CLOCK_QUALIFIER)
+                                        .hasSingleBean(JwksHealthCache.class)
+                                        .hasSingleBean(JwksHealthIndicator.class));
+    }
+
+    @Test
+    void should_still_create_jwks_health_executor_when_differently_named_executor_bean_exists() {
+        contextRunner
+                .withPropertyValues("management.health.jwks.enabled=true")
+                .withBean("testExecutor", ExecutorService.class, Executors::newSingleThreadExecutor)
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasBean(JWKS_HEALTH_EXECUTOR_QUALIFIER)
+                                        .hasSingleBean(JwksHealthCache.class)
+                                        .hasSingleBean(JwksHealthIndicator.class));
     }
 
     @Test

--- a/oidc-rs-spring-boot-webflux-config/src/main/java/org/entur/auth/spring/config/ConfigReactiveJwksHealthIndicatorAutoConfiguration.java
+++ b/oidc-rs-spring-boot-webflux-config/src/main/java/org/entur/auth/spring/config/ConfigReactiveJwksHealthIndicatorAutoConfiguration.java
@@ -30,14 +30,17 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 @ConditionalOnWebApplication(type = REACTIVE)
 @ConditionalOnEnabledHealthIndicator("jwks")
 public class ConfigReactiveJwksHealthIndicatorAutoConfiguration {
+    private static final String JWKS_CLOCK_QUALIFIER = "jwksClock";
+    private static final String JWKS_HEALTH_EXECUTOR_QUALIFIER = "jwksHealthExecutor";
+
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = JWKS_CLOCK_QUALIFIER)
     public @NonNull Clock jwksClock() {
         return systemDefaultZone();
     }
 
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = JWKS_HEALTH_EXECUTOR_QUALIFIER)
     public @NonNull ExecutorService jwksHealthExecutor() {
         return newSingleThreadExecutor(new CustomizableThreadFactory("jwks-health-"));
     }
@@ -45,8 +48,8 @@ public class ConfigReactiveJwksHealthIndicatorAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public @NonNull JwksHealthCache jwksHealthCache(
-            final @NonNull @Qualifier("jwksClock") Clock clock,
-            final @NonNull @Qualifier("jwksHealthExecutor") ExecutorService executor) {
+            final @NonNull @Qualifier(JWKS_CLOCK_QUALIFIER) Clock clock,
+            final @NonNull @Qualifier(JWKS_HEALTH_EXECUTOR_QUALIFIER) ExecutorService executor) {
         return new JwksHealthCache(clock, executor, ofSeconds(5));
     }
 

--- a/oidc-rs-spring-boot-webflux-config/src/test/java/org/entur/auth/spring/config/ConfigReactiveJwksHealthIndicatorAutoConfigurationTest.java
+++ b/oidc-rs-spring-boot-webflux-config/src/test/java/org/entur/auth/spring/config/ConfigReactiveJwksHealthIndicatorAutoConfigurationTest.java
@@ -19,6 +19,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import lombok.val;
@@ -95,6 +97,32 @@ class ConfigReactiveJwksHealthIndicatorAutoConfigurationTest {
                                 assertThat(context)
                                         .doesNotHaveBean(JwksHealthCache.class)
                                         .doesNotHaveBean(JwksHealthIndicator.class));
+    }
+
+    @Test
+    void should_still_create_jwks_clock_when_differently_named_clock_bean_exists() {
+        contextRunner
+                .withPropertyValues("management.health.jwks.enabled=true")
+                .withBean("testClock", Clock.class, Clock::systemDefaultZone)
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasBean(JWKS_CLOCK_QUALIFIER)
+                                        .hasSingleBean(JwksHealthCache.class)
+                                        .hasSingleBean(JwksHealthIndicator.class));
+    }
+
+    @Test
+    void should_still_create_jwks_health_executor_when_differently_named_executor_bean_exists() {
+        contextRunner
+                .withPropertyValues("management.health.jwks.enabled=true")
+                .withBean("testExecutor", ExecutorService.class, Executors::newSingleThreadExecutor)
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasBean(JWKS_HEALTH_EXECUTOR_QUALIFIER)
+                                        .hasSingleBean(JwksHealthCache.class)
+                                        .hasSingleBean(JwksHealthIndicator.class));
     }
 
     @Test


### PR DESCRIPTION
## 💡 What does this PR do?
This pull request addresses a bean conflict issue upon construction of JWKS health indicator. The proposed solution is to use qualifiers to avoid bean conflicts.

## 🔧 List of changes
- Use qualifiers to avoid bean conflicts
- Add tests

## 📋 Checklist
- [x] Am familiar with the release pipeline for this project
- [ ] I have updated relevant developer documentation
- [ ] I have updated relevant user documentation
- [x] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes